### PR TITLE
Oculus Shader workaroud

### DIFF
--- a/src/main/java/dev/latvian/mods/literalskyblock/integration/IrisCompat.java
+++ b/src/main/java/dev/latvian/mods/literalskyblock/integration/IrisCompat.java
@@ -4,6 +4,7 @@ import com.mojang.logging.LogUtils;
 import net.coderbot.iris.Iris;
 import net.coderbot.iris.pipeline.WorldRenderingPhase;
 import net.coderbot.iris.pipeline.WorldRenderingPipeline;
+import net.irisshaders.iris.api.v0.IrisApi;
 import net.minecraft.client.renderer.LevelRenderer;
 import org.slf4j.Logger;
 
@@ -31,8 +32,8 @@ public class IrisCompat {
         try {
             final WorldRenderingPipeline pipeline = Iris.getPipelineManager().preparePipeline(Iris.getCurrentDimension());
             PIPELINE.set(renderer, pipeline);
-            pipeline.beginLevelRendering();
-            pipeline.setPhase(WorldRenderingPhase.NONE);
+            //pipeline.beginLevelRendering();
+            pipeline.setOverridePhase(WorldRenderingPhase.NONE);
         } catch (ReflectiveOperationException e) {
             LOGGER.error("Exception in preRender", e);
         }
@@ -42,10 +43,14 @@ public class IrisCompat {
         if (PIPELINE == null) return;
         try {
             final WorldRenderingPipeline pipeline = (WorldRenderingPipeline)PIPELINE.get(renderer);
-            pipeline.finalizeLevelRendering();
+            //pipeline.finalizeLevelRendering();
             PIPELINE.set(renderer, null);
         } catch (ReflectiveOperationException e) {
             LOGGER.error("Exception in postRender", e);
         }
+    }
+
+    public static boolean shadersEnabled() {
+        return IrisApi.getInstance().isShaderPackInUse();
     }
 }


### PR DESCRIPTION
Added @Gaming32 shadersEnabled(), if it should be needed for a proper fix, this "fix" makes shaders "work" but Sky and Void Block become transparent instead of the world being a textureless mess.

beginLevelRendering (and finalizeLevelRendering) is what makes the world textureless, overriding the pipeline phase makes the GUI not invisible